### PR TITLE
Add Firebase redirect compatibility shim

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,5 +1,5 @@
 import { initializeApp, getApps } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
+import { getAuth, signInWithRedirect } from 'firebase/auth';
 
 const env = (key) => process.env[key];
 
@@ -22,3 +22,11 @@ const existingApp = getApps()[0];
 export const firebaseApp = firebaseConfigMissing ? null : existingApp || initializeApp(config);
 
 export const firebaseAuth = firebaseApp ? getAuth(firebaseApp) : null;
+
+// Provide a minimal compatibility layer for code paths that expect signInWithRedirect
+// to exist as a method on the Auth instance. The modular SDK exposes it as a
+// standalone function instead, which can lead to `TypeError: signInWithRedirect is
+// not a function` errors when older integrations call `auth.signInWithRedirect(...)`.
+if (firebaseAuth && typeof firebaseAuth.signInWithRedirect !== 'function') {
+  firebaseAuth.signInWithRedirect = (provider) => signInWithRedirect(firebaseAuth, provider);
+}


### PR DESCRIPTION
## Summary
- add a compatibility shim for `signInWithRedirect` on the modular Firebase auth instance to prevent runtime errors

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949441b6b0883228db70ad4706d5d4d)