### PR TITLE
Implement Firestore-backed getDealsForUser

### DIFF
--- a/src/lib/deals/getDealsForUser.ts
+++ b/src/lib/deals/getDealsForUser.ts
@@ -1,0 +1,33 @@
+import admin from '../firebase/admin';
+
+type FirestoreDeal = Record<string, unknown>;
+
+export type Deal = FirestoreDeal & {
+  id?: string;
+};
+
+export const getDealsForUser = async (userId?: string | null): Promise<Deal[]> => {
+  if (!userId) {
+    return [];
+  }
+
+  try {
+    if (!admin.apps.length) {
+      return [];
+    }
+
+    const firestore = admin.firestore?.();
+    if (!firestore) {
+      return [];
+    }
+
+    const snapshot = await firestore.collection('deals').where('ownerId', '==', userId).get();
+
+    return snapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...(doc.data() as FirestoreDeal),
+    }));
+  } catch {
+    return [];
+  }
+};


### PR DESCRIPTION
### Motivation
- Replace the previous stub with a real Firestore-backed implementation that fetches deals for the currently authenticated user while failing silently (returning an empty array) when the user is unauthenticated or Firestore is unavailable, preserving the existing `Deal` contract and avoiding runtime errors.

### Description
- Add `src/lib/deals/getDealsForUser.ts` which exports `getDealsForUser`; it imports the existing Firebase admin client from `../firebase/admin`, returns `[]` for missing `userId`, verifies `admin.apps.length` and `admin.firestore()` before querying the `deals` collection with `.where('ownerId', '==', userId)`, maps documents to the preserved `Deal` shape including `id`, and catches errors to return an empty array.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f89b54a88322a7ff23cfd2ec6cc1)