### PR TITLE
Use Firebase auth context in getDealsForUser

### DIFF
--- a/src/lib/deals/getDealsForUser.ts
+++ b/src/lib/deals/getDealsForUser.ts
@@ -1,4 +1,5 @@
 import admin from '../firebase/admin';
+import { firebaseAuth } from '../../firebase';
 
 type FirestoreDeal = Record<string, unknown>;
 
@@ -7,7 +8,9 @@ export type Deal = FirestoreDeal & {
 };
 
 export const getDealsForUser = async (userId?: string | null): Promise<Deal[]> => {
-  if (!userId) {
+  const resolvedUserId = userId ?? firebaseAuth?.currentUser?.uid ?? null;
+
+  if (!resolvedUserId) {
     return [];
   }
 
@@ -21,7 +24,7 @@ export const getDealsForUser = async (userId?: string | null): Promise<Deal[]> =
       return [];
     }
 
-    const snapshot = await firestore.collection('deals').where('ownerId', '==', userId).get();
+    const snapshot = await firestore.collection('deals').where('ownerId', '==', resolvedUserId).get();
 
     return snapshot.docs.map((doc) => ({
       id: doc.id,


### PR DESCRIPTION
### Motivation
- Ensure `getDealsForUser` uses the existing Firebase authentication context to require a valid `userId` and return an empty array when unauthenticated.

### Description
- Import `firebaseAuth` and resolve `resolvedUserId = userId ?? firebaseAuth?.currentUser?.uid ?? null`, return `[]` if missing, and use `resolvedUserId` in the Firestore `deals` query in `src/lib/deals/getDealsForUser.ts`, preserving the `Deal` type and existing error/admin guards.

### Testing
- No automated tests were executed for this change; please run `npm run dev` and `npm run typecheck` in CI or locally to validate runtime and types.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698600e0072483229ef48a528dbbfecf)